### PR TITLE
Unread count now loads when third party cookies are disabled

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -76,7 +76,7 @@ var CommaFeed = {
 		catch(ex) { /* user is using Firefox 3.5 */ }
 		xhr.open("GET", url + "rest/category/unreadCount", true);
 		xhr.onreadystatechange = function() {
-			if (xhr.readyState == 4) {
+			if (xhr.readyState == 4 && xhr.status == 200) {
 				var resp = JSON.parse(xhr.responseText);
 				var count = 0;
 				for ( var i = 0; i < resp.length; i++) {


### PR DESCRIPTION
See: https://forums.mozilla.org/addons/viewtopic.php?f=7&t=1421

Fixes issue #2

Currently, if you disable 3rd party cookies in Firefox, the unread count displays "NaN" because the request is unauthorized due to the cookie not being sent. The addon then attempts to parse the response text which isn't json.
